### PR TITLE
fix: clean up unused vars and mock

### DIFF
--- a/app/src/components/Layout/AppLayout.tsx
+++ b/app/src/components/Layout/AppLayout.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 import { Sidebar } from "./Sidebar";
 import { Header } from "./Header";
 import { useWorkspace } from "@/lib/contexts/WorkspaceContext";
@@ -7,10 +7,9 @@ import { WorkspaceSwitcherModal } from "@/components/Workspace/WorkspaceSwitcher
 import { useAuth } from "@/contexts/AuthContext";
 
 export const AppLayout: React.FC = () => {
-  const { currentWorkspace, isLoading, workspaces } = useWorkspace();
+  const { currentWorkspace, isLoading } = useWorkspace();
   const { isAuthenticated } = useAuth();
   const [showSwitcher, setShowSwitcher] = useState(false);
-  const location = useLocation();
 
   useEffect(() => {
     // Only show workspace switcher if authenticated, not loading, and has no current workspace

--- a/app/src/lib/api/__mocks__/CommentsApi.ts
+++ b/app/src/lib/api/__mocks__/CommentsApi.ts
@@ -1,1 +1,13 @@
- 
+import { vi } from 'vitest';
+
+export const initializeStorage = vi.fn().mockResolvedValue(undefined);
+export const getComments = vi.fn().mockResolvedValue([]);
+export const getCommentById = vi.fn().mockResolvedValue(null);
+export const getCommentsByContentItem = vi.fn().mockResolvedValue([]);
+export const getPendingComments = vi.fn().mockResolvedValue([]);
+export const saveComment = vi.fn().mockResolvedValue({});
+export const saveComments = vi.fn().mockResolvedValue([]);
+export const deleteComment = vi.fn().mockResolvedValue(undefined);
+export const approveComment = vi.fn().mockResolvedValue({});
+export const rejectComment = vi.fn().mockResolvedValue({});
+export const getThreadedComments = vi.fn().mockResolvedValue([]);


### PR DESCRIPTION
- remove unused `workspaces` and `location` variables
- implement CommentsApi mock to satisfy linter